### PR TITLE
Melhoria para envio de dados binários

### DIFF
--- a/brief.json
+++ b/brief.json
@@ -2,7 +2,7 @@
   "description": "Router module",
   "name": "router",
   "path": "index.js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "Nery Jr",
   "dependencies": [ ]
 }

--- a/index.js
+++ b/index.js
@@ -55,7 +55,9 @@ var router = {
 
         httpResponse.setStatus(response.status)
         httpResponse.setContentType(response.contentType)
-        httpResponse.setCharacterEncoding(response.charset)
+        if(response.charset) {
+            httpResponse.setCharacterEncoding(response.charset)
+        }
 
         for (var key in response.headers) {
             httpResponse.setHeader(key, response.headers[key])


### PR DESCRIPTION
Ajuste no router para definir o charset da request apenas quando ele está definido. No caso dados binários não é necessário informar o charset.